### PR TITLE
custom metro config to load the mini manifest without relative paths

### DIFF
--- a/metro-config.js
+++ b/metro-config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { getDefaultConfig } = require("metro-config");
 
 module.exports.getMinisMetroConfig = async function getMinisMetroConfig() {
@@ -22,6 +23,25 @@ module.exports.getMinisMetroConfig = async function getMinisMetroConfig() {
       assetExts: assetExts.filter((ext) => ext !== "svg"),
       sourceExts: [...sourceExts, "svg"],
       platforms: ["ios", "android"],
+      resolveRequest: (context, moduleName, platform) => {
+        // use a custom path instead of a relative import to load the mini manifest
+        if (moduleName === "minis:manifest") {
+          const manifestPath = path.join(process.cwd(), "src", "manifest.json");
+          try {
+            return {
+              filePath: require.resolve(manifestPath),
+              type: "sourceFile",
+            };
+          } catch (err) {
+            // This shouldn't really happen, the CLI would explode before actually launching metro.
+            console.warn(`Your manifest file could not be found in path ${manifestPath}`);
+            return { type: "empty" };
+          }
+        }
+
+        // Chain to the standard Metro resolver for modules other than the manifest.
+        return context.resolveRequest(context, moduleName, platform);
+      },
     },
   };
 };


### PR DESCRIPTION
## Part of https://github.com/Shopify/shop-minis-cli/issues/203#issuecomment-1642138696

## Summary

As part of https://github.com/Shopify/shop-minis-cli/issues/203, we need to be able to read the remote mini manifest from the minis-sdk, so that we read the value of `trusted_domains` to allow execution of `minisFetch`.

We can use relative paths, assuming that minisFetch will always be located in `node_modules/@shopify/shop-minis-platform-sdk/src/utils/minisFetch.ts`, we can import the manifest with the following statement: `require('../../../../../src/manifest.json')` which will go back to the rootpath and then try to load the file `manifest.json` from the `src` folder.

First problem with the relative approach is that it makes error handling hard, if the manifest file does not exist or contains syntax errors, the app will just crash. (we can't try/catch requires with metro)

Second problem with the relative import is that (IMO) it's fragile, and if we end up having the need to change paths for some reason the we would need to deal with breaking changes on the SDK, partners using new versions of it, old versions, codemods, etc.


I believe this can be simplified if we move the manifest resolution to the metro config (that lives in shop-minis-runtime (this repo)) and use absolute paths instead (process.cwd + src + manifest.json), hence, this PR.

With this config, we can load the manifest from the sdk using `require('minis:manifest')`