### PR TITLE
Allow all-hooks to be rendered in the browser

### DIFF
--- a/all-hooks/src/components/demos/Orders.tsx
+++ b/all-hooks/src/components/demos/Orders.tsx
@@ -3,7 +3,6 @@ import {
   useOrders,
   type Order,
   type Money,
-  CurrencyCode,
 } from '@shopify/shop-minis-react'
 
 function formatPrice(money: Money): string {
@@ -119,7 +118,7 @@ export function Orders() {
             }, 0)
             const currency =
               order.lineItems[0]?.product?.price?.currencyCode ||
-              CurrencyCode.USD
+              'USD'
 
             return (
               <div

--- a/all-hooks/src/main.tsx
+++ b/all-hooks/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
+import '@shopify/shop-minis-react/mocks'
 import { MinisContainer } from '@shopify/shop-minis-react'
 
 import { App } from './App.jsx'


### PR DESCRIPTION
-  [x] Allows mocks on the all-hooks mini
-  [x] Fixes the CurrencyCode by hardcoding it.